### PR TITLE
Support for static SPIRV-Cross, MSVC cleanup <> to "", void* warning

### DIFF
--- a/SDL_gpu_shadercross.h
+++ b/SDL_gpu_shadercross.h
@@ -223,7 +223,7 @@ static pfn_spvc_compiler_compile SDL_spvc_compiler_compile = NULL;
 static pfn_spvc_context_get_last_error_string SDL_spvc_context_get_last_error_string = NULL;
 static pfn_spvc_compiler_get_execution_model SDL_spvc_compiler_get_execution_model = NULL;
 static pfn_spvc_compiler_get_cleansed_entry_point_name SDL_spvc_compiler_get_cleansed_entry_point_name = NULL;
-#else // SDL_GPU_SHADERCROSS_STATIC
+#else /* SDL_GPU_SHADERCROSS_STATIC */
 #define SDL_spvc_context_create spvc_context_create
 #define SDL_spvc_context_destroy spvc_context_destroy
 #define SDL_spvc_context_parse_spirv spvc_context_parse_spirv
@@ -235,7 +235,7 @@ static pfn_spvc_compiler_get_cleansed_entry_point_name SDL_spvc_compiler_get_cle
 #define SDL_spvc_context_get_last_error_string spvc_context_get_last_error_string
 #define SDL_spvc_compiler_get_execution_model spvc_compiler_get_execution_model
 #define SDL_spvc_compiler_get_cleansed_entry_point_name spvc_compiler_get_cleansed_entry_point_name
-#endif // SDL_GPU_SHADERCROSS_STATIC
+#endif /* SDL_GPU_SHADERCROSS_STATIC */
 
 #define SPVC_ERROR(func) \
     SDL_SetError(#func " failed: %s", SDL_spvc_context_get_last_error_string(context))
@@ -307,7 +307,7 @@ void *SDL_CompileFromSPIRV(
     CHECK_FUNC(spvc_compiler_get_execution_model)
     CHECK_FUNC(spvc_compiler_get_cleansed_entry_point_name)
 #undef CHECK_FUNC
-#endif // SDL_GPU_SHADERCROSS_STATIC
+#endif /* SDL_GPU_SHADERCROSS_STATIC */
 
     /* Create the SPIRV-Cross context */
     result = SDL_spvc_context_create(&context);

--- a/SDL_gpu_shadercross.h
+++ b/SDL_gpu_shadercross.h
@@ -190,13 +190,15 @@ void *SDL_CompileFromHLSL(
 #include "spirv_cross_c.h"
 
 #ifndef SDL_GPU_SHADERCROSS_STATIC
-#if defined(_WIN32)
-#define SPIRV_CROSS_DLL "spirv-cross-c-shared.dll"
-#elif defined(__APPLE__)
-#define SPIRV_CROSS_DLL "libspirv-cross-c-shared.0.dylib"
-#else
-#define SPIRV_CROSS_DLL "libspirv-cross-c-shared.so.0"
-#endif
+	#ifndef SDL_GPU_SPIRV_CROSS_DLL
+		#if defined(_WIN32)
+			#define SDL_GPU_SPIRV_CROSS_DLL "spirv-cross-c-shared.dll"
+		#elif defined(__APPLE__)
+			#define SDL_GPU_SPIRV_CROSS_DLL "libspirv-cross-c-shared.0.dylib"
+		#else
+		#define SDL_GPU_SPIRV_CROSS_DLL "libspirv-cross-c-shared.so.0"
+	#endif /* SDL_GPU_SPIRV_CROSS_DLL */
+#endif /* SDL_GPU_SHADERCROSS_STATIC */
 
 static void *spirvcross_dll = NULL;
 
@@ -282,7 +284,7 @@ void *SDL_CompileFromSPIRV(
     /* FIXME: spirv-cross could probably be loaded in a better spot */
 #ifndef SDL_GPU_SHADERCROSS_STATIC
     if (spirvcross_dll == NULL) {
-        spirvcross_dll = SDL_LoadObject(SPIRV_CROSS_DLL);
+        spirvcross_dll = SDL_LoadObject(SDL_GPU_SPIRV_CROSS_DLL);
         if (spirvcross_dll == NULL) {
             return NULL;
         }

--- a/SDL_gpu_shadercross.h
+++ b/SDL_gpu_shadercross.h
@@ -159,7 +159,7 @@ void *SDL_CompileFromHLSL(
     if (shaderProfile[0] == 'c' && shaderProfile[1] == 's') {
         SDL_GpuComputePipelineCreateInfo newCreateInfo;
         newCreateInfo = *(SDL_GpuComputePipelineCreateInfo *)createInfo;
-        newCreateInfo.code = (const uint8_t*)blob->lpVtbl->GetBufferPointer(blob);
+        newCreateInfo.code = (const Uint8*)blob->lpVtbl->GetBufferPointer(blob);
         newCreateInfo.codeSize = blob->lpVtbl->GetBufferSize(blob);
         newCreateInfo.format = SDL_GPU_SHADERFORMAT_DXBC;
 
@@ -167,7 +167,7 @@ void *SDL_CompileFromHLSL(
     } else {
         SDL_GpuShaderCreateInfo newCreateInfo;
         newCreateInfo = *(SDL_GpuShaderCreateInfo *)createInfo;
-        newCreateInfo.code = (const uint8_t*)blob->lpVtbl->GetBufferPointer(blob);
+        newCreateInfo.code = (const Uint8*)blob->lpVtbl->GetBufferPointer(blob);
         newCreateInfo.codeSize = blob->lpVtbl->GetBufferSize(blob);
         newCreateInfo.format = SDL_GPU_SHADERFORMAT_DXBC;
 
@@ -196,7 +196,8 @@ void *SDL_CompileFromHLSL(
 		#elif defined(__APPLE__)
 			#define SDL_GPU_SPIRV_CROSS_DLL "libspirv-cross-c-shared.0.dylib"
 		#else
-		#define SDL_GPU_SPIRV_CROSS_DLL "libspirv-cross-c-shared.so.0"
+			#define SDL_GPU_SPIRV_CROSS_DLL "libspirv-cross-c-shared.so.0"
+		#endif
 	#endif /* SDL_GPU_SPIRV_CROSS_DLL */
 #endif /* SDL_GPU_SHADERCROSS_STATIC */
 


### PR DESCRIPTION
Spent some time today trying this out with MSVC2022. I maintain a small 2D game creation framework and wanted to try out SDL_Gpu. There were a couple difficulties here since I statically linked SPIRV-Cross.

My understanding is the current implementation assumes SPIRV-Cross is installed by the user before trying out this header. Though, I don't want users of my framework to have to bother installing anything external, besides CMake/python.

```c++
#define SPIRV_CROSS_DLL "spirv-cross-c-shared.dll"
```

This line doesn't actually seem super helpful for anyone compiling from source, shared or not. I noticed the default behavior from SPIRV-Cross's cmake file was to created `spriv-cross-c.dll`, not `spirv-cross-c-shared.dll`, so I assume the -shared name came perhaps from a vcpkg install? Maybe you could help explain this bit. Let me know if you have thoughts here, I'm totally new to all this SPIR-V stuff and might be just a total dumb idiot here.

I decided to try adding `SDL_GPU_SHADERCROSS_STATIC` to eliminate all the function pointer loading, and this worked pretty well. It's an optional define similar to `SDL_GPU_SHADERCROSS_IMPLEMENTATION`.

I did swap `#include<spirv_cross_c.h>` to #include "spirv_cross_c.h", this makes it a bit easier to integrate all the headers together with a relative path here. I don't actually have `#include<spirv_cross_c.h>` on the path, so this include gives an error under MSVC2022.

The last bit were some minor warnings on assigning from `void*`, since C++ is a little pickier on type conversions here