### PR TITLE
C++ compile fixes (MSVC 2022)

### DIFF
--- a/SDL_gpu_shadercross.h
+++ b/SDL_gpu_shadercross.h
@@ -325,12 +325,12 @@ static void *SDL_ShaderCross_INTERNAL_CompileDXC(
 
     /* Try to load DXIL, we don't need it directly but if it doesn't exist the code will not be loadable */
     if (!spirv) {
-        if (!SDL_LoadObject(DXIL_DLL)) {
+        void* dxil_dll = SDL_LoadObject(DXIL_DLL);
+        if (dxil_dll == NULL) {
             SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to load DXIL library, this will cause pipeline creation failures!");
             return NULL;
         }
-        // ???
-        //SDL_UnloadObject(DXIL_DLL);
+        SDL_UnloadObject(dxil_dll); /* Unload immediately, we don't actually need it*/ 
     }
 
     if (SDL_DxcCreateInstance == NULL) {

--- a/SDL_gpu_shadercross.h
+++ b/SDL_gpu_shadercross.h
@@ -305,8 +305,8 @@ static void *SDL_ShaderCross_INTERNAL_CompileDXC(
     IDxcBlob *blob;
     IDxcBlobUtf8 *errors;
     LPCWSTR args[] = {
-        L"-E",
-        L"main", /* FIXME */
+        (LPCWSTR)L"-E",
+        (LPCWSTR)L"main", /* FIXME */
         NULL,
         NULL,
         NULL
@@ -329,7 +329,8 @@ static void *SDL_ShaderCross_INTERNAL_CompileDXC(
             SDL_LogError(SDL_LOG_CATEGORY_GPU, "Failed to load DXIL library, this will cause pipeline creation failures!");
             return NULL;
         }
-        SDL_UnloadObject(DXIL_DLL);
+        // ???
+        //SDL_UnloadObject(DXIL_DLL);
     }
 
     if (SDL_DxcCreateInstance == NULL) {
@@ -353,18 +354,18 @@ static void *SDL_ShaderCross_INTERNAL_CompileDXC(
     source.Encoding = 0; /* FIXME: The docs for this are a _bit_ scarce */
 
     if (SDL_strcmp(shaderProfile, "ps_6_0") == 0) {
-        args[argCount++] = L"-T";
-        args[argCount++] = L"ps_6_0";
+        args[argCount++] = (LPCWSTR)L"-T";
+        args[argCount++] = (LPCWSTR)L"ps_6_0";
     } else if (SDL_strcmp(shaderProfile, "vs_6_0") == 0) {
-        args[argCount++] = L"-T";
-        args[argCount++] = L"vs_6_0";
+        args[argCount++] = (LPCWSTR)L"-T";
+        args[argCount++] = (LPCWSTR)L"vs_6_0";
     } else if (SDL_strcmp(shaderProfile, "cs_6_0") == 0) {
-        args[argCount++] = L"-T";
-        args[argCount++] = L"cs_6_0";
+        args[argCount++] = (LPCWSTR)L"-T";
+        args[argCount++] = (LPCWSTR)L"cs_6_0";
     }
 
     if (spirv) {
-        args[argCount++] = L"-spirv";
+        args[argCount++] = (LPCWSTR)L"-spirv";
     }
 
     ret = SDL_DxcInstance->lpVtbl->Compile(


### PR DESCRIPTION
I was actually quite confused on why the wide char assignments here weren't compiling. I suspect it's just a quirk of MSVC. Looking into the typedefs they match, but there was a failure to implicitly cast from a C-array to pointer. Odd. Any thoughts?

I also noticed what looks like an erroneous call to `SDL_UnloadObject(DXIL_DLL);`. Passing in a path doesn't make sense for this function, and it need not be called in the case of failure to load anyways. This was also causing a compile error in C++ since the string cannot implicitly cast down to `void*` as in C.