### PR TITLE
Move compiler loading to an init function

### DIFF
--- a/SDL_gpu_shadercross.h
+++ b/SDL_gpu_shadercross.h
@@ -912,12 +912,12 @@ SDL_bool SDL_ShaderCross_Init(void)
         CHECK_FUNC(spvc_compiler_get_cleansed_entry_point_name)
 #undef CHECK_FUNC
     }
-#endif /* SDL_GPU_SHADERCROSS_STATIC */
 
     if(spirvcross_dll != NULL && !spvc_loaded) {
         SDL_UnloadObject(spirvcross_dll);
         spirvcross_dll = NULL;
     }
+#endif /* SDL_GPU_SHADERCROSS_STATIC */
 
     return SDL_TRUE;
 }
@@ -971,7 +971,13 @@ SDL_GPUShaderFormat SDL_ShaderCross_GetSPIRVShaderFormats()
     SDL_GPUShaderFormat supportedFormats = SDL_GPU_SHADERFORMAT_SPIRV;
 
     /* SPIRV-Cross allows us to cross compile to MSL */
-    if(spirvcross_dll != NULL) {
+    if (
+#ifndef SDL_GPU_SHADERCROSS_STATIC
+        spirvcross_dll != NULL
+#else /* SDL_GPU_SHADERCROSS_STATIC */
+        true
+#endif /* SDL_GPU_SHADERCROSS_STATIC */
+    ) {
         supportedFormats |= SDL_GPU_SHADERFORMAT_MSL;
 
 #if SDL_GPU_SHADERCROSS_HLSL

--- a/SDL_gpu_shadercross.h
+++ b/SDL_gpu_shadercross.h
@@ -973,19 +973,19 @@ SDL_GPUShaderFormat SDL_ShaderCross_GetSPIRVShaderFormats()
     /* SPIRV-Cross allows us to cross compile to MSL */
     if(spirvcross_dll != NULL) {
         supportedFormats |= SDL_GPU_SHADERFORMAT_MSL;
-    }
 
 #if SDL_GPU_SHADERCROSS_HLSL
-    /* SPIRV-Cross + DXC allows us to cross-compile to HLSL, then compile to DXIL */
-    if(dxcompiler_dll != NULL) {
-        supportedFormats |= SDL_GPU_SHADERFORMAT_DXIL;
-    }
+        /* SPIRV-Cross + DXC allows us to cross-compile to HLSL, then compile to DXIL */
+        if(dxcompiler_dll != NULL) {
+            supportedFormats |= SDL_GPU_SHADERFORMAT_DXIL;
+        }
 
-    /* SPIRV-Cross + FXC allows us to cross-compile to HLSL, then compile to DXBC */
-    if(d3dcompiler_dll != NULL) {
-        supportedFormats |= SDL_GPU_SHADERFORMAT_DXBC;
-    }
+        /* SPIRV-Cross + FXC allows us to cross-compile to HLSL, then compile to DXBC */
+        if(d3dcompiler_dll != NULL) {
+            supportedFormats |= SDL_GPU_SHADERFORMAT_DXBC;
+        }
 #endif /* SDL_GPU_SHADERCROSS_HLSL */
+    }
 
     return supportedFormats;
 }


### PR DESCRIPTION
Closes #7 

Do note that I'm not the most comfortable with C, so I may have made some beginner mistakes with this PR.

This PR also comes bundled with a couple tiny other changes I made while doing this refactor, notably
- `SDL_ShaderCross_GetShaderFormats` has been split in two, and the returned formats are accurate to what is actually possible to generate given the loaded compilers
- `SDL_ShaderCross_INTERNAL_CompileDXC` takes in an `encoding` parameter, however it is left unexposed past that, since FXC cannot handle it. Maybe its something worth allowing in the future with a safety check on the FXC path? I don't think its *particularly* uncommon to want to use unicode characters in comments and such.
- Refactored `SDL_ShaderCross_INTERNAL_CompileDXC` to create a new `IDxcCompiler3` every call, allowing the function to be thread-safe. Maybe this could be made thread-local in the future to allow re-use, if supported by the C compiler.
- Basic docs, following the style of SDL